### PR TITLE
Improve performance, especially for large frames

### DIFF
--- a/common/src/main/java/io/github/moremcmeta/moremcmeta/api/client/texture/ColorTransform.java
+++ b/common/src/main/java/io/github/moremcmeta/moremcmeta/api/client/texture/ColorTransform.java
@@ -29,7 +29,8 @@ public interface ColorTransform {
      * Calculates the new color of the pixel at the given coordinate in the frame being modified.
      * While this method only takes the x and y-coordinates of the pixel, a {@link FrameView} for
      * the frame being modified is available in contexts where a {@link ColorTransform} would be
-     * provided.
+     * provided.<b>This method may be called from multiple threads concurrently. If there is any
+     * state shared between calls, it must be synchronized properly for concurrent usage.</b>
      * @param overwriteX            x-coordinate of the location of the pixel whose color will be replaced
      * @param overwriteY            y-coordinate of the location of the pixel whose color will be replaced
      * @param layerBelow            retrieves the color of pixels in the layer below this plugin's layer.

--- a/common/src/main/java/io/github/moremcmeta/moremcmeta/api/client/texture/MutableFrameView.java
+++ b/common/src/main/java/io/github/moremcmeta/moremcmeta/api/client/texture/MutableFrameView.java
@@ -29,9 +29,7 @@ public interface MutableFrameView extends FrameView {
     /**
      * Modifies the predefined frame by applying the given {@link ColorTransform} over
      * the given area. There is no ordering guaranteed for how the transform will be applied
-     * over the provided points. <b>This method may be called from multiple threads concurrently.
-     * If there is any state shared between calls, it must be synchronized properly for
-     * concurrent usage.</b>
+     * over the provided points.
      * @param transform     the transformation to apply to the given points
      * @param applyArea     the points to apply the transformation to
      * @throws PixelOutOfBoundsException if a pixel in `applyArea` is out of the frame's bounds

--- a/common/src/main/java/io/github/moremcmeta/moremcmeta/api/client/texture/MutableFrameView.java
+++ b/common/src/main/java/io/github/moremcmeta/moremcmeta/api/client/texture/MutableFrameView.java
@@ -29,7 +29,9 @@ public interface MutableFrameView extends FrameView {
     /**
      * Modifies the predefined frame by applying the given {@link ColorTransform} over
      * the given area. There is no ordering guaranteed for how the transform will be applied
-     * over the provided points.
+     * over the provided points. <b>This method may be called from multiple threads concurrently.
+     * If there is any state shared between calls, it must be synchronized properly for
+     * concurrent usage.</b>
      * @param transform     the transformation to apply to the given points
      * @param applyArea     the points to apply the transformation to
      * @throws PixelOutOfBoundsException if a pixel in `applyArea` is out of the frame's bounds

--- a/common/src/main/java/io/github/moremcmeta/moremcmeta/api/client/texture/TextureComponent.java
+++ b/common/src/main/java/io/github/moremcmeta/moremcmeta/api/client/texture/TextureComponent.java
@@ -36,14 +36,16 @@ public interface TextureComponent<V> {
     default void onTick(V currentFrame, FrameGroup<? extends PersistentFrameView> predefinedFrames) {}
 
     /**
-     * Responds when the associated texture is "used." There is no guarantee about what texture will be bound
-     * when this method is called. Note that the lifetime of the {@link CurrentFrameView} provided to this method
-     * is limited to the call of this method. Attempting to retain and use a {@link CurrentFrameView} at a later
-     * point will cause a {@link IllegalFrameReferenceException} exception to be thrown.
+     * Responds to the tick event of the associated texture after several ticks have passed. This method will be
+     * called at least as often as the texture is used. Note that the lifetime of the {@link CurrentFrameView}
+     * provided to this method is limited to the call of this method. Attempting to retain and use a
+     * {@link CurrentFrameView} at a later point will cause a {@link IllegalFrameReferenceException} exception
+     * to be thrown.
      * @param currentFrame      view of the texture's current frame
      * @param predefinedFrames  persistent views of all predefined frames
+     * @param ticks             number of ticks that have passed since the last time this method was called
      */
-    default void onUse(V currentFrame, FrameGroup<? extends PersistentFrameView> predefinedFrames) {}
+    default void onTick(V currentFrame, FrameGroup<? extends PersistentFrameView> predefinedFrames, int ticks) {}
 
     /**
      * Responds to the close event of the associated texture. Note that the lifetime of the {@link CurrentFrameView}

--- a/common/src/main/java/io/github/moremcmeta/moremcmeta/api/client/texture/TextureComponent.java
+++ b/common/src/main/java/io/github/moremcmeta/moremcmeta/api/client/texture/TextureComponent.java
@@ -36,6 +36,16 @@ public interface TextureComponent<V> {
     default void onTick(V currentFrame, FrameGroup<? extends PersistentFrameView> predefinedFrames) {}
 
     /**
+     * Responds when the associated texture is "used." There is no guarantee about what texture will be bound
+     * when this method is called. Note that the lifetime of the {@link CurrentFrameView} provided to this method
+     * is limited to the call of this method. Attempting to retain and use a {@link CurrentFrameView} at a later
+     * point will cause a {@link IllegalFrameReferenceException} exception to be thrown.
+     * @param currentFrame      view of the texture's current frame
+     * @param predefinedFrames  persistent views of all predefined frames
+     */
+    default void onUse(V currentFrame, FrameGroup<? extends PersistentFrameView> predefinedFrames) {}
+
+    /**
      * Responds to the close event of the associated texture. Note that the lifetime of the {@link CurrentFrameView}
      * provided to this method is limited to the call of this method. Attempting to retain and use a
      * {@link CurrentFrameView} at a later point will cause a {@link IllegalFrameReferenceException} exception

--- a/common/src/main/java/io/github/moremcmeta/moremcmeta/api/math/Area.java
+++ b/common/src/main/java/io/github/moremcmeta/moremcmeta/api/math/Area.java
@@ -17,17 +17,21 @@
 
 package io.github.moremcmeta.moremcmeta.api.math;
 
+import com.google.common.collect.ImmutableList;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectSortedMap;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongImmutableList;
 import it.unimi.dsi.fastutil.longs.LongIterable;
 import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongIterators;
+import it.unimi.dsi.fastutil.longs.LongList;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
 
 /**
  * Represents an unordered collection of points.
@@ -66,7 +70,8 @@ public final class Area implements LongIterable {
         return builder.build();
     }
 
-    private final Set<Row> ROWS;
+    // Each long list represents a segment of (leftX, segmentWidth) pairs
+    private final Int2ObjectSortedMap<LongList> ROWS;
 
     /**
      * Creates a new area that represents a rectangle.
@@ -90,11 +95,11 @@ public final class Area implements LongIterable {
             throw new RectangleOverflowException(topLeftX, topLeftY, width, height);
         }
 
-        ROWS = new HashSet<>();
+        ROWS = new Int2ObjectRBTreeMap<>();
 
         if (width > 0) {
             for (int y = topLeftY; y < topLeftY + height; y++) {
-                ROWS.add(new Row(topLeftX, y, width));
+                ROWS.put(y, new LongImmutableList(ImmutableList.of(Point.pack(topLeftX, width))));
             }
         }
     }
@@ -105,7 +110,7 @@ public final class Area implements LongIterable {
      */
     @Override
     public @NotNull LongIterator iterator() {
-        return new PointIterator(ROWS);
+        return new PointIterator();
     }
 
     /**
@@ -116,13 +121,13 @@ public final class Area implements LongIterable {
     public static final class Builder {
 
         // Keys are y (row) coordinates. Values are x (column) coordinates.
-        private final Map<Integer, Set<Integer>> ROWS;
+        private final Int2ObjectSortedMap<IntList> ROWS;
 
         /**
          * Creates a new builder for an area.
          */
         public Builder() {
-            ROWS = new HashMap<>();
+            ROWS = new Int2ObjectRBTreeMap<>();
         }
 
         /**
@@ -132,7 +137,7 @@ public final class Area implements LongIterable {
          */
         public void addPixel(int x, int y) {
             if (!ROWS.containsKey(y)) {
-                ROWS.put(y, new HashSet<>());
+                ROWS.put(y, new IntArrayList());
             }
 
             ROWS.get(y).add(x);
@@ -151,10 +156,11 @@ public final class Area implements LongIterable {
          * @return  the area
          */
         public Area build() {
-            Set<Row> rows = new HashSet<>();
+            Int2ObjectSortedMap<LongList> rows = new Int2ObjectRBTreeMap<>();
 
-            for (Map.Entry<Integer, Set<Integer>> entry : ROWS.entrySet()) {
-                List<Integer> xPoints = entry.getValue().stream().sorted().toList();
+            for (Int2ObjectMap.Entry<IntList> entry : ROWS.int2ObjectEntrySet()) {
+                IntList xPoints = entry.getValue();
+                xPoints.sort(Integer::compare);
                 int numPoints = xPoints.size();
 
                 int startIndex = 0;
@@ -162,11 +168,13 @@ public final class Area implements LongIterable {
                     int nextIndex = pointIndex + 1;
 
                     boolean isLastPoint = pointIndex == numPoints - 1;
-                    boolean isRowEnd = isLastPoint || xPoints.get(nextIndex) - xPoints.get(pointIndex) > 1;
+                    boolean isRowEnd = isLastPoint || xPoints.getInt(nextIndex) - xPoints.getInt(pointIndex) > 1;
 
                     if (isRowEnd) {
                         int width = pointIndex - startIndex + 1;
-                        rows.add(new Row(xPoints.get(startIndex), entry.getKey(), width));
+                        int y = entry.getIntKey();
+                        rows.computeIfAbsent(y, (key) -> new LongArrayList())
+                                .add(Point.pack(xPoints.getInt(startIndex), width));
 
                         startIndex = nextIndex;
                     }
@@ -182,67 +190,32 @@ public final class Area implements LongIterable {
      * Creates a new area.
      * @param rows  all the horizontal strips in this image
      */
-    private Area(Set<Row> rows) {
+    private Area(Int2ObjectSortedMap<LongList> rows) {
         ROWS = rows;
-    }
-
-    /**
-     * Represents continuous, one-pixel-high horizontal strips in an image.
-     * @author soir20
-     */
-    private static class Row {
-        private final int X;
-        private final int Y;
-        private final int WIDTH;
-
-        /**
-         * Creates a new row in this image.
-         * @param x         left x-coordinate of the row
-         * @param y         left y-coordinate of the row
-         * @param width     width of the row in pixels
-         */
-        public Row(int x, int y, int width) {
-            X = x;
-            Y = y;
-            WIDTH = width;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(X, Y, WIDTH);
-        }
-
-        @Override
-        public boolean equals(Object other) {
-            if (!(other instanceof Row otherRow)) {
-                return false;
-            }
-
-            return X == otherRow.X && Y == otherRow.Y && WIDTH == ((Row) other).WIDTH;
-        }
-
     }
 
     /**
      * Iterates over all the points in a {@link Area}.
      * @author soir20
      */
-    private static class PointIterator implements LongIterator {
-        private final Iterator<Row> rowIterator;
-        private Row currentRow;
+    private class PointIterator implements LongIterator {
+        private final Iterator<Int2ObjectMap.Entry<LongList>> ROW_ITERATOR = ROWS.int2ObjectEntrySet().iterator();
+        private int currentRowY;
+        private LongIterator segmentIterator;
+        private int currentSegmentX;
+        private int currentSegmentWidth;
         private int pixelCount;
 
         /**
          * Creates a new iterator.
-         * @param rows      all the rows in the area
          */
-        public PointIterator(Set<Row> rows) {
-            rowIterator = rows.iterator();
+        public PointIterator() {
+            segmentIterator = LongIterators.EMPTY_ITERATOR;
         }
 
         @Override
         public boolean hasNext() {
-            return rowIterator.hasNext() || (currentRow != null && pixelCount < currentRow.WIDTH);
+            return ROW_ITERATOR.hasNext() || segmentIterator.hasNext() || pixelCount < currentSegmentWidth;
         }
 
         /**
@@ -251,13 +224,23 @@ public final class Area implements LongIterable {
          */
         @Override
         public long nextLong() {
-            if (currentRow == null || pixelCount == currentRow.WIDTH) {
-                currentRow = rowIterator.next();
+            boolean atSegmentEnd = pixelCount == currentSegmentWidth;
+
+            if (atSegmentEnd && !segmentIterator.hasNext()) {
+                Int2ObjectMap.Entry<LongList> currentRow = ROW_ITERATOR.next();
+                segmentIterator = currentRow.getValue().iterator();
+                currentRowY = currentRow.getIntKey();
+            }
+
+            if (atSegmentEnd) {
+                long currentSegment = segmentIterator.nextLong();
+                currentSegmentX = Point.x(currentSegment);
+                currentSegmentWidth = Point.y(currentSegment);
                 pixelCount = 0;
             }
 
             pixelCount++;
-            return Point.pack(currentRow.X + pixelCount - 1, currentRow.Y);
+            return Point.pack(currentSegmentX + pixelCount - 1, currentRowY);
         }
 
     }

--- a/common/src/main/java/io/github/moremcmeta/moremcmeta/impl/adt/SparseIntMatrix.java
+++ b/common/src/main/java/io/github/moremcmeta/moremcmeta/impl/adt/SparseIntMatrix.java
@@ -18,7 +18,7 @@
 package io.github.moremcmeta.moremcmeta.impl.adt;
 
 import java.util.BitSet;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Stream;
 
 /**
@@ -39,7 +39,7 @@ import java.util.stream.Stream;
  */
 public final class SparseIntMatrix {
     private final BitSet[] IS_PRESENT;
-    private final ReentrantLock[] LOCKS;
+    private final ReentrantReadWriteLock[] LOCKS;
     private final int WIDTH;
     private final int HEIGHT;
     private final int[][] MATRIX;
@@ -91,9 +91,9 @@ public final class SparseIntMatrix {
         IS_PRESENT = Stream.generate(() -> new BitSet(SECTOR_SIZE))
                 .limit((long) SECTORS_PER_ROW * rows)
                 .toArray(BitSet[]::new);
-        LOCKS = Stream.generate(ReentrantLock::new)
+        LOCKS = Stream.generate(ReentrantReadWriteLock::new)
                 .limit((long) SECTORS_PER_ROW * rows)
-                .toArray(ReentrantLock[]::new);
+                .toArray(ReentrantReadWriteLock[]::new);
     }
 
     /**
@@ -108,7 +108,7 @@ public final class SparseIntMatrix {
         int sectorIndex = sectorIndex(x, y);
         int indexInSector = indexInSector(x, y);
 
-        ReentrantLock lock = LOCKS[sectorIndex];
+        ReentrantReadWriteLock.ReadLock lock = LOCKS[sectorIndex].readLock();
         lock.lock();
 
         if (!IS_PRESENT[sectorIndex].get(indexInSector)) {
@@ -132,7 +132,7 @@ public final class SparseIntMatrix {
         int sectorIndex = sectorIndex(x, y);
         int indexInSector = indexInSector(x, y);
 
-        ReentrantLock lock = LOCKS[sectorIndex];
+        ReentrantReadWriteLock.ReadLock lock = LOCKS[sectorIndex].readLock();
 
         lock.lock();
         boolean isSet = IS_PRESENT[sectorIndex].get(indexInSector);
@@ -154,7 +154,7 @@ public final class SparseIntMatrix {
         int sectorIndex = sectorIndex(x, y);
         int indexInSector = indexInSector(x, y);
 
-        ReentrantLock lock = LOCKS[sectorIndex];
+        ReentrantReadWriteLock.WriteLock lock = LOCKS[sectorIndex].writeLock();
         lock.lock();
 
         if (MATRIX[sectorIndex] == null) {

--- a/common/src/main/java/io/github/moremcmeta/moremcmeta/impl/client/texture/CloseableImageFrame.java
+++ b/common/src/main/java/io/github/moremcmeta/moremcmeta/impl/client/texture/CloseableImageFrame.java
@@ -24,8 +24,16 @@ import io.github.moremcmeta.moremcmeta.api.math.Area;
 import io.github.moremcmeta.moremcmeta.api.math.Point;
 import io.github.moremcmeta.moremcmeta.impl.adt.SparseIntMatrix;
 import io.github.moremcmeta.moremcmeta.impl.client.io.FrameReader;
-import it.unimi.dsi.fastutil.longs.LongArrayFIFOQueue;
-import it.unimi.dsi.fastutil.longs.LongPriorityQueue;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongList;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static java.util.Objects.requireNonNull;
 
@@ -34,6 +42,8 @@ import static java.util.Objects.requireNonNull;
  * @author soir20
  */
 public class CloseableImageFrame {
+    private static final ExecutorService THREAD_POOL = Executors.newCachedThreadPool();
+    private static final int SUB_AREA_SIZE_HINT = 128 * 128;
     private final int WIDTH;
     private final int HEIGHT;
     private final ImmutableList<Layer> LOWER_LAYERS;
@@ -245,52 +255,60 @@ public class CloseableImageFrame {
 
         // Apply transformation to the original image
         Layer thisLayer = layer == TOP_LAYER_INDEX ? TOP_LAYER : LOWER_LAYERS.get(layer);
-        applyArea.forEach((point) -> {
-            int x = Point.x(point);
-            int y = Point.y(point);
-            checkPointInBounds(x, y);
+        List<LongList> results = new ArrayList<>();
 
-            int newColor = transform.transform(x, y, (depX, depY) -> {
-                checkPointInBounds(depX, depY);
-                return layerBelow.read(depX, depY);
-            });
-            thisLayer.write(x, y, newColor);
-        });
+        if (applyArea.size() > SUB_AREA_SIZE_HINT) {
+            List<Callable<LongList>> tasks = applyArea.split(SUB_AREA_SIZE_HINT).stream()
+                    .<Callable<LongList>>map((subArea) -> () -> applyTransform(transform, layerBelow, thisLayer, subArea))
+                    .toList();
+
+            try {
+                for (Future<LongList> future : THREAD_POOL.invokeAll(tasks)) {
+                    results.add(future.get());
+                }
+            } catch (InterruptedException err) {
+                throw new RuntimeException("Parallel frame generation was interrupted", err);
+            } catch (ExecutionException err) {
+                throw new RuntimeException("Exception during frame generation", err);
+            }
+        } else {
+            results.add(applyTransform(transform, layerBelow, thisLayer, applyArea));
+        }
 
         /* Update corresponding mipmap pixels.
            Plugins have no knowledge of mipmaps, and giving them that
            knowledge would require all of them to handle additional
            complexity. Instead, we can efficiently calculate the mipmaps
            ourselves. */
-        while (!TOP_LAYER.lastModified().isEmpty()) {
-            long point = TOP_LAYER.lastModified().dequeueLong();
+        for (int level = 1; level <= mipmapLevel(); level++) {
+            for (LongList lastModified : results) {
+                for (long point : lastModified) {
+                    int x = Point.x(point);
+                    int y = Point.y(point);
 
-            int x = Point.x(point);
-            int y = Point.y(point);
-            for (int level = 1; level <= mipmapLevel(); level++) {
+                    // Don't try to set a color when the mipmap is empty
+                    if (mipmaps.get(level).width() == 0 && mipmaps.get(level).height() == 0) {
+                        break;
+                    }
 
-                // Don't try to set a color when the mipmap is empty
-                if (mipmaps.get(level).width() == 0 && mipmaps.get(level).height() == 0) {
-                    break;
+                    int cornerX = makeEven(x >> (level - 1));
+                    int cornerY = makeEven(y >> (level - 1));
+
+                    CloseableImage prevImage = mipmaps.get(level - 1);
+                    int topLeft = prevImage.color(cornerX, cornerY);
+                    int topRight = prevImage.color(cornerX + 1, cornerY);
+                    int bottomLeft = prevImage.color(cornerX, cornerY + 1);
+                    int bottomRight = prevImage.color(cornerX + 1, cornerY + 1);
+
+                    int blended = ColorBlender.blend(
+                            topLeft,
+                            topRight,
+                            bottomLeft,
+                            bottomRight
+                    );
+
+                    mipmaps.get(level).setColor(x >> level, y >> level, blended);
                 }
-
-                int cornerX = makeEven(x >> (level - 1));
-                int cornerY = makeEven(y >> (level - 1));
-
-                CloseableImage prevImage = mipmaps.get(level - 1);
-                int topLeft = prevImage.color(cornerX, cornerY);
-                int topRight = prevImage.color(cornerX + 1, cornerY);
-                int bottomLeft = prevImage.color(cornerX, cornerY + 1);
-                int bottomRight = prevImage.color(cornerX + 1, cornerY + 1);
-
-                int blended = ColorBlender.blend(
-                        topLeft,
-                        topRight,
-                        bottomLeft,
-                        bottomRight
-                );
-
-                mipmaps.get(level).setColor(x >> level, y >> level, blended);
             }
         }
 
@@ -353,6 +371,35 @@ public class CloseableImageFrame {
     }
 
     /**
+     * Applies a transform to a sub area.
+     * @param transform     transform to apply
+     * @param layerBelow    layer below the layer being modified
+     * @param thisLayer     layer being modified
+     * @param subArea       sub area to apply the transform to
+     * @return all points where the underlying image was modified
+     */
+    private LongList applyTransform(ColorTransform transform, Layer layerBelow, Layer thisLayer, Area subArea) {
+        LongList modifiedPoints = new LongArrayList();
+
+        subArea.forEach((point) -> {
+            int x = Point.x(point);
+            int y = Point.y(point);
+            checkPointInBounds(x, y);
+
+            int newColor = transform.transform(x, y, (depX, depY) -> {
+                checkPointInBounds(depX, depY);
+                return layerBelow.read(depX, depY);
+            });
+
+            if (thisLayer.write(x, y, newColor)) {
+                modifiedPoints.add(point);
+            }
+        });
+
+        return modifiedPoints;
+    }
+
+    /**
      * Convert a number to the closest even integer that is smaller than
      * the given integer.
      * @param num           number to make even
@@ -377,8 +424,9 @@ public class CloseableImageFrame {
          * @param x         the x-coordinate to write the color at
          * @param y         the y-coordinate to write the color at
          * @param color     the color to write
+         * @return whether the underlying image was modified
          */
-        void write(int x, int y, int color);
+        boolean write(int x, int y, int color);
 
         /**
          * Reads a color from the specified point in this layer.
@@ -426,9 +474,9 @@ public class CloseableImageFrame {
         }
 
         @Override
-        public void write(int x, int y, int color) {
+        public boolean write(int x, int y, int color) {
             POINTS.set(x, y, color);
-            TOP_LAYER.tryWrite(x, y, color, INDEX);
+            return TOP_LAYER.tryWrite(x, y, color, INDEX);
         }
 
         @Override
@@ -467,9 +515,9 @@ public class CloseableImageFrame {
         }
 
         @Override
-        public void write(int x, int y, int color) {
+        public boolean write(int x, int y, int color) {
             POINTS.set(x, y, color);
-            TOP_LAYER.tryWrite(x, y, color, INDEX);
+            return TOP_LAYER.tryWrite(x, y, color, INDEX);
         }
 
         @Override
@@ -490,7 +538,6 @@ public class CloseableImageFrame {
         private final int WIDTH;
         private final byte INDEX;
         private final byte[] MODIFIED_BY;
-        private final LongPriorityQueue LAST_MODIFIED;
         private BottomLayer bottomLayer;
 
         /**
@@ -505,7 +552,6 @@ public class CloseableImageFrame {
             WIDTH = width;
             INDEX = index;
             MODIFIED_BY = new byte[width * height];
-            LAST_MODIFIED = new LongArrayFIFOQueue();
         }
 
         /**
@@ -517,26 +563,18 @@ public class CloseableImageFrame {
         }
 
         /**
-         * Retrieves the queue of points that have been modified in this layer. The returned
-         * queue is mutable. Note that it is possible for the queue to contain duplicates.
-         * @return the modified points in the topmost layer
-         */
-        public LongPriorityQueue lastModified() {
-            return LAST_MODIFIED;
-        }
-
-        /**
          * Writes to this layer from a lower layer. If the top layer has already
          * written to itself at the given point, then this method does nothing.
          * @param x         the x-coordinate to try to write to
          * @param y         the y-coordinate to try to write to
          * @param color     the color to write at the given point
          * @param layer     the layer that is writing to this layer
+         * @return whether the color was written to this layer
          */
-        public void tryWrite(int x, int y, int color, byte layer) {
+        public boolean tryWrite(int x, int y, int color, byte layer) {
             int pointIndex = pointIndex(x, y);
             if (layer < MODIFIED_BY[pointIndex]) {
-                return;
+                return false;
             }
 
             /* Attempting to write to the bottom layer handles three different cases:
@@ -561,12 +599,12 @@ public class CloseableImageFrame {
 
             IMAGE.setColor(x, y, color);
             MODIFIED_BY[pointIndex] = layer;
-            LAST_MODIFIED.enqueue(Point.pack(x, y));
+            return true;
         }
 
         @Override
-        public void write(int x, int y, int color) {
-            tryWrite(x, y, color, INDEX);
+        public boolean write(int x, int y, int color) {
+            return tryWrite(x, y, color, INDEX);
         }
 
         @Override

--- a/common/src/main/java/io/github/moremcmeta/moremcmeta/impl/client/texture/EventDrivenTexture.java
+++ b/common/src/main/java/io/github/moremcmeta/moremcmeta/impl/client/texture/EventDrivenTexture.java
@@ -94,6 +94,8 @@ public final class EventDrivenTexture extends AbstractTexture implements CustomT
     public void upload(ResourceLocation base) {
         requireNonNull(base, "Base cannot be null");
 
+        runListeners((component, view) -> component.onUse(view, CURRENT_STATE.predefinedFrames()));
+
         if (!CURRENT_STATE.BASES_UPLOADED_SINCE_UPDATE.contains(base)) {
             CURRENT_STATE.BASES_UPLOADED_SINCE_UPDATE.add(base);
 

--- a/common/src/main/java/io/github/moremcmeta/moremcmeta/impl/client/texture/EventDrivenTexture.java
+++ b/common/src/main/java/io/github/moremcmeta/moremcmeta/impl/client/texture/EventDrivenTexture.java
@@ -63,6 +63,7 @@ public final class EventDrivenTexture extends AbstractTexture implements CustomT
 
     private final List<CoreTextureComponent> COMPONENTS;
     private final TextureState CURRENT_STATE;
+    private int ticks;
 
     @Override
     public void setFilter(boolean blur, boolean clamp) {
@@ -80,6 +81,7 @@ public final class EventDrivenTexture extends AbstractTexture implements CustomT
     @Override
     public void tick() {
         runListeners((component, view) -> component.onTick(view, CURRENT_STATE.predefinedFrames()));
+        ticks = Math.max(0, ticks + 1);
     }
 
     @Override
@@ -94,7 +96,8 @@ public final class EventDrivenTexture extends AbstractTexture implements CustomT
     public void upload(ResourceLocation base) {
         requireNonNull(base, "Base cannot be null");
 
-        runListeners((component, view) -> component.onUse(view, CURRENT_STATE.predefinedFrames()));
+        runListeners((component, view) -> component.onTick(view, CURRENT_STATE.predefinedFrames(), ticks));
+        ticks = 0;
 
         if (!CURRENT_STATE.BASES_UPLOADED_SINCE_UPDATE.contains(base)) {
             CURRENT_STATE.BASES_UPLOADED_SINCE_UPDATE.add(base);
@@ -207,9 +210,9 @@ public final class EventDrivenTexture extends AbstractTexture implements CustomT
                 }
 
                 @Override
-                public void onUse(TextureAndFrameView currentFrame,
-                                   FrameGroup<? extends PersistentFrameView> predefinedFrames) {
-                    component.onUse(currentFrame, predefinedFrames);
+                public void onTick(TextureAndFrameView currentFrame,
+                                   FrameGroup<? extends PersistentFrameView> predefinedFrames, int ticks) {
+                    component.onTick(currentFrame, predefinedFrames, ticks);
                 }
 
                 @Override

--- a/common/src/main/java/io/github/moremcmeta/moremcmeta/impl/client/texture/EventDrivenTexture.java
+++ b/common/src/main/java/io/github/moremcmeta/moremcmeta/impl/client/texture/EventDrivenTexture.java
@@ -30,6 +30,7 @@ import net.minecraft.client.renderer.texture.AbstractTexture;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -347,6 +348,7 @@ public final class EventDrivenTexture extends AbstractTexture implements CustomT
         /**
          * Flags the texture as needing an upload.
          */
+        @VisibleForTesting
         public void markNeedsUpload() {
             checkValid();
             STATE.markNeedsUpload();

--- a/common/src/main/java/io/github/moremcmeta/moremcmeta/impl/client/texture/EventDrivenTexture.java
+++ b/common/src/main/java/io/github/moremcmeta/moremcmeta/impl/client/texture/EventDrivenTexture.java
@@ -207,6 +207,12 @@ public final class EventDrivenTexture extends AbstractTexture implements CustomT
                 }
 
                 @Override
+                public void onUse(TextureAndFrameView currentFrame,
+                                   FrameGroup<? extends PersistentFrameView> predefinedFrames) {
+                    component.onUse(currentFrame, predefinedFrames);
+                }
+
+                @Override
                 public void onClose(TextureAndFrameView currentFrame,
                                     FrameGroup<? extends PersistentFrameView> predefinedFrames) {
                     component.onClose(currentFrame, predefinedFrames);

--- a/common/src/main/java/io/github/moremcmeta/moremcmeta/impl/client/texture/EventDrivenTexture.java
+++ b/common/src/main/java/io/github/moremcmeta/moremcmeta/impl/client/texture/EventDrivenTexture.java
@@ -96,8 +96,10 @@ public final class EventDrivenTexture extends AbstractTexture implements CustomT
     public void upload(ResourceLocation base) {
         requireNonNull(base, "Base cannot be null");
 
-        runListeners((component, view) -> component.onTick(view, CURRENT_STATE.predefinedFrames(), ticks));
-        ticks = 0;
+        if (ticks > 0) {
+            runListeners((component, view) -> component.onTick(view, CURRENT_STATE.predefinedFrames(), ticks));
+            ticks = 0;
+        }
 
         if (!CURRENT_STATE.BASES_UPLOADED_SINCE_UPDATE.contains(base)) {
             CURRENT_STATE.BASES_UPLOADED_SINCE_UPDATE.add(base);

--- a/common/src/test/java/io/github/moremcmeta/moremcmeta/api/math/AreaTest.java
+++ b/common/src/test/java/io/github/moremcmeta/moremcmeta/api/math/AreaTest.java
@@ -86,36 +86,42 @@ public final class AreaTest {
     public void construct_EmptyArea_ConstructedCorrectly() {
         Area rect = new Area(0, 0, 0, 0);
         assertFalse(rect.iterator().hasNext());
+        assertEquals(0, rect.size());
     }
 
     @Test
     public void construct_EmptyWidthArea_ConstructedCorrectly() {
         Area rect = new Area(0, 0, 0, 10);
         assertFalse(rect.iterator().hasNext());
+        assertEquals(0, rect.size());
     }
 
     @Test
     public void construct_EmptyHeightArea_ConstructedCorrectly() {
         Area rect = new Area(0, 0, 10, 0);
         assertFalse(rect.iterator().hasNext());
+        assertEquals(0, rect.size());
     }
 
     @Test
     public void iterator_PositiveAreaAtCorner_AllPointsIterated() {
         Area rect = new Area(Integer.MAX_VALUE - 10, Integer.MAX_VALUE - 20, 10, 20);
         testIteratedRectangle(rect, Integer.MAX_VALUE - 10, Integer.MAX_VALUE - 20, 10, 20);
+        assertEquals(10 * 20, rect.size());
     }
 
     @Test
     public void iterator_NegativeAreaAtCorner_AllPointsIterated() {
         Area rect = new Area(Integer.MIN_VALUE, Integer.MIN_VALUE, 10, 20);
         testIteratedRectangle(rect, Integer.MIN_VALUE, Integer.MIN_VALUE, 10, 20);
+        assertEquals(10 * 20, rect.size());
     }
 
     @Test
     public void iterator_PositiveAndNegativeArea_AllPointsIterated() {
         Area rect = new Area(-5, -15, 11, 19);
         testIteratedRectangle(rect, -5, -15, 11, 19);
+        assertEquals(11 * 19, rect.size());
     }
 
     @Test
@@ -135,6 +141,7 @@ public final class AreaTest {
         Area.Builder builder = new Area.Builder();
         Area area = builder.build();
         assertFalse(area.iterator().hasNext());
+        assertEquals(0, area.size());
     }
 
     @Test
@@ -166,6 +173,7 @@ public final class AreaTest {
 
         assertTrue(areaPoints.containsAll(points));
         assertEquals(points.size(), areaPoints.size());
+        assertEquals(points.size(), area.size());
     }
 
     @Test
@@ -197,6 +205,7 @@ public final class AreaTest {
 
         assertTrue(areaPoints.containsAll(points));
         assertEquals(points.size(), areaPoints.size());
+        assertEquals(points.size(), area.size());
     }
 
     @Test
@@ -227,6 +236,7 @@ public final class AreaTest {
 
         assertTrue(areaPoints.containsAll(points));
         assertEquals(points.size(), areaPoints.size());
+        assertEquals(points.size(), area.size());
     }
 
     @Test
@@ -264,6 +274,7 @@ public final class AreaTest {
 
         assertTrue(areaPoints.containsAll(points));
         assertTrue(areaPoints.stream().allMatch(new HashSet<>()::add));
+        assertEquals(points.size(), area.size());
     }
 
     @Test
@@ -294,6 +305,7 @@ public final class AreaTest {
 
         assertTrue(areaPoints.containsAll(points));
         assertEquals(points.size(), areaPoints.size());
+        assertEquals(points.size(), area.size());
     }
 
     @Test
@@ -326,6 +338,7 @@ public final class AreaTest {
 
         assertTrue(areaPoints.containsAll(points));
         assertEquals(points.size(), areaPoints.size());
+        assertEquals(points.size(), area.size());
     }
 
     @Test
@@ -358,6 +371,7 @@ public final class AreaTest {
 
         assertTrue(areaPoints.containsAll(points));
         assertEquals(points.size(), areaPoints.size());
+        assertEquals(points.size(), area.size());
     }
 
     @Test
@@ -389,6 +403,7 @@ public final class AreaTest {
 
         assertTrue(areaPoints.containsAll(points));
         assertEquals(points.size(), areaPoints.size());
+        assertEquals(points.size(), area.size());
     }
 
     @Test
@@ -420,6 +435,7 @@ public final class AreaTest {
 
         assertTrue(areaPoints.containsAll(points));
         assertEquals(points.size(), areaPoints.size());
+        assertEquals(points.size(), area.size());
     }
 
     @Test
@@ -450,6 +466,7 @@ public final class AreaTest {
 
         assertTrue(areaPoints.containsAll(points));
         assertEquals(points.size(), areaPoints.size());
+        assertEquals(points.size(), area.size());
     }
 
     @Test
@@ -487,6 +504,7 @@ public final class AreaTest {
 
         assertTrue(areaPoints.containsAll(points));
         assertTrue(areaPoints.stream().allMatch(new HashSet<>()::add));
+        assertEquals(points.size(), area.size());
     }
 
     @Test
@@ -517,6 +535,7 @@ public final class AreaTest {
 
         assertTrue(areaPoints.containsAll(points));
         assertEquals(points.size(), areaPoints.size());
+        assertEquals(points.size(), area.size());
     }
 
     @Test
@@ -549,6 +568,7 @@ public final class AreaTest {
 
         assertTrue(areaPoints.containsAll(points));
         assertEquals(points.size(), areaPoints.size());
+        assertEquals(points.size(), area.size());
     }
 
     @Test
@@ -581,6 +601,202 @@ public final class AreaTest {
 
         assertTrue(areaPoints.containsAll(points));
         assertEquals(points.size(), areaPoints.size());
+        assertEquals(points.size(), area.size());
+    }
+
+    @Test
+    public void split_NegativeSizeHint_NegativeDimensionException() {
+        Area.Builder builder = new Area.Builder();
+        List<Long> points = new ArrayList<>();
+        points.add(Point.pack(0, 0));
+        points.add(Point.pack(0, 1));
+        points.add(Point.pack(0, 2));
+        points.add(Point.pack(1, 3));
+        points.add(Point.pack(1, 4));
+        points.add(Point.pack(1, 8));
+        points.add(Point.pack(1, 12));
+        points.add(Point.pack(1, 13));
+        points.add(Point.pack(2, 0));
+        points.add(Point.pack(2, 1));
+        points.add(Point.pack(2, 2));
+        points.add(Point.pack(2, 3));
+
+        for (long point : points) {
+            builder.addPixel(point);
+        }
+
+        Area area = builder.build();
+
+        expectedException.expect(NegativeDimensionException.class);
+        area.split(-1);
+    }
+
+    @Test
+    public void split_ZeroSizeHint_AllPointsIncluded() {
+        Area.Builder builder = new Area.Builder();
+        List<Long> points = new ArrayList<>();
+        points.add(Point.pack(0, 0));
+        points.add(Point.pack(0, 1));
+        points.add(Point.pack(0, 2));
+        points.add(Point.pack(1, 3));
+        points.add(Point.pack(1, 4));
+        points.add(Point.pack(1, 8));
+        points.add(Point.pack(1, 12));
+        points.add(Point.pack(1, 13));
+        points.add(Point.pack(2, 0));
+        points.add(Point.pack(2, 1));
+        points.add(Point.pack(2, 2));
+        points.add(Point.pack(2, 3));
+
+        for (long point : points) {
+            builder.addPixel(point);
+        }
+
+        Area area = builder.build();
+
+        List<Long> areaPoints = new ArrayList<>();
+        int totalArea = 0;
+        for (Area subArea : area.split(0)) {
+            totalArea += subArea.size();
+            for (long point : subArea) {
+                areaPoints.add(point);
+            }
+        }
+
+        assertTrue(areaPoints.containsAll(points));
+        assertEquals(points.size(), areaPoints.size());
+        assertEquals(points.size(), area.size());
+        assertEquals(totalArea, area.size());
+    }
+
+    @Test
+    public void split_SizeHintSmallerThanAreaSize_AllPointsIncluded() {
+        Area.Builder builder = new Area.Builder();
+        List<Long> points = new ArrayList<>();
+        points.add(Point.pack(0, 0));
+        points.add(Point.pack(0, 1));
+        points.add(Point.pack(0, 2));
+        points.add(Point.pack(1, 3));
+        points.add(Point.pack(1, 4));
+        points.add(Point.pack(1, 8));
+        points.add(Point.pack(1, 12));
+        points.add(Point.pack(1, 13));
+        points.add(Point.pack(2, 0));
+        points.add(Point.pack(2, 1));
+        points.add(Point.pack(2, 2));
+        points.add(Point.pack(2, 3));
+
+        for (long point : points) {
+            builder.addPixel(point);
+        }
+
+        Area area = builder.build();
+
+        List<Long> areaPoints = new ArrayList<>();
+        int totalArea = 0;
+        for (Area subArea : area.split(5)) {
+            totalArea += subArea.size();
+            for (long point : subArea) {
+                areaPoints.add(point);
+            }
+        }
+
+        assertTrue(areaPoints.containsAll(points));
+        assertEquals(points.size(), areaPoints.size());
+        assertEquals(points.size(), area.size());
+        assertEquals(totalArea, area.size());
+    }
+
+    @Test
+    public void split_SizeHintEqualToAreaSize_AllPointsIncluded() {
+        Area.Builder builder = new Area.Builder();
+        List<Long> points = new ArrayList<>();
+        points.add(Point.pack(0, 0));
+        points.add(Point.pack(0, 1));
+        points.add(Point.pack(0, 2));
+        points.add(Point.pack(1, 3));
+        points.add(Point.pack(1, 4));
+        points.add(Point.pack(1, 8));
+        points.add(Point.pack(1, 12));
+        points.add(Point.pack(1, 13));
+        points.add(Point.pack(2, 0));
+        points.add(Point.pack(2, 1));
+        points.add(Point.pack(2, 2));
+        points.add(Point.pack(2, 3));
+
+        for (long point : points) {
+            builder.addPixel(point);
+        }
+
+        Area area = builder.build();
+
+        List<Long> areaPoints = new ArrayList<>();
+        int totalArea = 0;
+        for (Area subArea : area.split(points.size())) {
+            totalArea += subArea.size();
+            for (long point : subArea) {
+                areaPoints.add(point);
+            }
+        }
+
+        assertTrue(areaPoints.containsAll(points));
+        assertEquals(points.size(), areaPoints.size());
+        assertEquals(points.size(), area.size());
+        assertEquals(totalArea, area.size());
+    }
+
+    @Test
+    public void split_SizeHintLargerThanAreaSize_AllPointsIncluded() {
+        Area.Builder builder = new Area.Builder();
+        List<Long> points = new ArrayList<>();
+        points.add(Point.pack(0, 0));
+        points.add(Point.pack(0, 1));
+        points.add(Point.pack(0, 2));
+        points.add(Point.pack(1, 3));
+        points.add(Point.pack(1, 4));
+        points.add(Point.pack(1, 8));
+        points.add(Point.pack(1, 12));
+        points.add(Point.pack(1, 13));
+        points.add(Point.pack(2, 0));
+        points.add(Point.pack(2, 1));
+        points.add(Point.pack(2, 2));
+        points.add(Point.pack(2, 3));
+
+        for (long point : points) {
+            builder.addPixel(point);
+        }
+
+        Area area = builder.build();
+
+        List<Long> areaPoints = new ArrayList<>();
+        int totalArea = 0;
+        for (Area subArea : area.split(20)) {
+            totalArea += subArea.size();
+            for (long point : subArea) {
+                areaPoints.add(point);
+            }
+        }
+
+        assertTrue(areaPoints.containsAll(points));
+        assertEquals(points.size(), areaPoints.size());
+        assertEquals(points.size(), area.size());
+        assertEquals(totalArea, area.size());
+    }
+
+    @Test
+    public void split_EmptyArea_AllPointsIncluded() {
+        Area area = Area.of();
+
+        List<Long> areaPoints = new ArrayList<>();
+        for (Area subArea : area.split(0)) {
+            assertEquals(0, subArea.size());
+
+            for (long point : subArea) {
+                areaPoints.add(point);
+            }
+        }
+
+        assertTrue(areaPoints.isEmpty());
     }
 
     private static void testIteratedRectangle(Area rect, int topLeftX, int topLeftY, int width, int height) {

--- a/common/src/test/java/io/github/moremcmeta/moremcmeta/impl/client/texture/EventDrivenTextureTest.java
+++ b/common/src/test/java/io/github/moremcmeta/moremcmeta/impl/client/texture/EventDrivenTextureTest.java
@@ -1183,7 +1183,7 @@ public final class EventDrivenTextureTest {
         final int UPLOAD_ID_BASE = 4;
         final int TICK_ID_BASE = 7;
         final int CLOSE_ID_BASE = 10;
-        final int USE_ID_BASE = 13;
+        final int TICK_2_ID_BASE = 13;
 
         List<Integer> execOrder = new ArrayList<>();
 
@@ -1194,6 +1194,12 @@ public final class EventDrivenTextureTest {
                 public void onTick(EventDrivenTexture.TextureAndFrameView currentFrame, FrameGroup<? extends PersistentFrameView> predefinedFrames) {
                     if (flagForUpload) currentFrame.markNeedsUpload();
                     execOrder.add(TICK_ID_BASE + finalIndex);
+                }
+
+                @Override
+                public void onTick(EventDrivenTexture.TextureAndFrameView currentFrame, FrameGroup<? extends PersistentFrameView> predefinedFrames, int ticks) {
+                    if (flagForUpload) currentFrame.markNeedsUpload();
+                    execOrder.add(TICK_2_ID_BASE + finalIndex);
                 }
 
                 @Override
@@ -1212,12 +1218,6 @@ public final class EventDrivenTextureTest {
                 public void onUpload(EventDrivenTexture.TextureAndFrameView currentFrame, ResourceLocation baseLocation) {
                     if (flagForUpload) currentFrame.markNeedsUpload();
                     execOrder.add(UPLOAD_ID_BASE + finalIndex);
-                }
-
-                @Override
-                public void onUse(EventDrivenTexture.TextureAndFrameView currentFrame, FrameGroup<? extends PersistentFrameView> predefinedFrames) {
-                    if (flagForUpload) currentFrame.markNeedsUpload();
-                    execOrder.add(USE_ID_BASE + finalIndex);
                 }
             });
         }

--- a/common/src/test/java/io/github/moremcmeta/moremcmeta/impl/client/texture/EventDrivenTextureTest.java
+++ b/common/src/test/java/io/github/moremcmeta/moremcmeta/impl/client/texture/EventDrivenTextureTest.java
@@ -422,25 +422,25 @@ public final class EventDrivenTextureTest {
 
     @Test
     public void bind_SecondUploadNotNeeded_UploadFiredInOrderOnce() {
-        Integer[] expected = {13, 14, 15, 4, 5, 6, 13, 14, 15};
+        Integer[] expected = {4, 5, 6};
         testExpectedOrder((texture) -> {texture.upload(DUMMY_BASE_LOCATION); texture.upload(DUMMY_BASE_LOCATION);}, false, expected);
     }
 
     @Test
     public void bind_SecondUploadNeeded_UploadFiredInOrder() {
-        Integer[] expected = {13, 14, 15, 4, 5, 6, 7, 8, 9, 13, 14, 15, 4, 5, 6};
+        Integer[] expected = {4, 5, 6, 7, 8, 9, 13, 14, 15, 4, 5, 6};
         testExpectedOrder((texture) -> {texture.upload(DUMMY_BASE_LOCATION); texture.tick(); texture.upload(DUMMY_BASE_LOCATION);}, true, expected);
     }
 
     @Test
     public void upload_FirstUpload_UploadFiredInOrder() {
-        Integer[] expected = {13, 14, 15, 4, 5, 6};
+        Integer[] expected = {4, 5, 6};
         testExpectedOrder((texture) -> texture.upload(new ResourceLocation("dummy.png")), false, expected);
     }
 
     @Test
     public void upload_SecondUploadNotNeeded_FirstUploadOnly() {
-        Integer[] expected = {13, 14, 15, 4, 5, 6, 13, 14, 15};
+        Integer[] expected = {4, 5, 6};
         ResourceLocation dummyBase = new ResourceLocation("dummy.png");
         testExpectedOrder((texture) -> {texture.upload(dummyBase); texture.upload(dummyBase);}, false, expected);
 

--- a/common/src/test/java/io/github/moremcmeta/moremcmeta/impl/client/texture/EventDrivenTextureTest.java
+++ b/common/src/test/java/io/github/moremcmeta/moremcmeta/impl/client/texture/EventDrivenTextureTest.java
@@ -422,25 +422,25 @@ public final class EventDrivenTextureTest {
 
     @Test
     public void bind_SecondUploadNotNeeded_UploadFiredInOrderOnce() {
-        Integer[] expected = {4, 5, 6};
+        Integer[] expected = {13, 14, 15, 4, 5, 6, 13, 14, 15};
         testExpectedOrder((texture) -> {texture.upload(DUMMY_BASE_LOCATION); texture.upload(DUMMY_BASE_LOCATION);}, false, expected);
     }
 
     @Test
     public void bind_SecondUploadNeeded_UploadFiredInOrder() {
-        Integer[] expected = {4, 5, 6, 7, 8, 9, 4, 5, 6};
+        Integer[] expected = {13, 14, 15, 4, 5, 6, 7, 8, 9, 13, 14, 15, 4, 5, 6};
         testExpectedOrder((texture) -> {texture.upload(DUMMY_BASE_LOCATION); texture.tick(); texture.upload(DUMMY_BASE_LOCATION);}, true, expected);
     }
 
     @Test
     public void upload_FirstUpload_UploadFiredInOrder() {
-        Integer[] expected = {4, 5, 6};
+        Integer[] expected = {13, 14, 15, 4, 5, 6};
         testExpectedOrder((texture) -> texture.upload(new ResourceLocation("dummy.png")), false, expected);
     }
 
     @Test
     public void upload_SecondUploadNotNeeded_FirstUploadOnly() {
-        Integer[] expected = {4, 5, 6};
+        Integer[] expected = {13, 14, 15, 4, 5, 6, 13, 14, 15};
         ResourceLocation dummyBase = new ResourceLocation("dummy.png");
         testExpectedOrder((texture) -> {texture.upload(dummyBase); texture.upload(dummyBase);}, false, expected);
 
@@ -1183,6 +1183,7 @@ public final class EventDrivenTextureTest {
         final int UPLOAD_ID_BASE = 4;
         final int TICK_ID_BASE = 7;
         final int CLOSE_ID_BASE = 10;
+        final int USE_ID_BASE = 13;
 
         List<Integer> execOrder = new ArrayList<>();
 
@@ -1211,6 +1212,12 @@ public final class EventDrivenTextureTest {
                 public void onUpload(EventDrivenTexture.TextureAndFrameView currentFrame, ResourceLocation baseLocation) {
                     if (flagForUpload) currentFrame.markNeedsUpload();
                     execOrder.add(UPLOAD_ID_BASE + finalIndex);
+                }
+
+                @Override
+                public void onUse(EventDrivenTexture.TextureAndFrameView currentFrame, FrameGroup<? extends PersistentFrameView> predefinedFrames) {
+                    if (flagForUpload) currentFrame.markNeedsUpload();
+                    execOrder.add(USE_ID_BASE + finalIndex);
                 }
             });
         }


### PR DESCRIPTION
## What did you change?
Improved general performance and performance for animations with large frames.

## Why did you make this change?
Performance with resource packs that contain large animation frames was extremely poor (1-2 FPS on my computer with the example presented in #39).

## How did you make this change?
* Added a new `onTick()` handler for `TextureComponent` that is called at least as often as the texture updates with the number of ticks that passed since the last call as the parameter.
* Reimplemented the `Area` class to use longs to avoid unnecessary object creation and memory usage.
* Added a method to `Area` to partition the area into roughly-equally sized "buckets" based on a provided size hint.
* Added concurrency support to `SparseIntMatrix` with read-write locks. A write lock is used whenever a new sector may be allocated or a pixel value is changed. The implementation of `SparseIntMatrix` was changed to use a single index to access sectors rather than two indices. While this uses more memory, it avoids a more complicated locking scheme and the need to lock large sections of the matrix at the same time.
* Changed `applyTransform()` of `CloseableImageFrame` to partition large areas and process them on multiple threads.
  * A cached thread pool reduces overhead from starting many threads. The [default thread pool](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executors.html#newCachedThreadPool--) removes threads when they have not been assigned any tasks for 60 seconds.
  * For areas less than 128 * 128 pixels in size, the current thread is used to avoid unnecessary overhead.
  * For areas greater than 128 * 128 pixels in size, the area is partitioned into sub-areas approximately 128 * 128 pixels in size.
  * The 128 * 128 value was determined experimentally. Lower values lead to significantly less stability in FPS (presumably due to thread scheduling). Higher values negated the performance improvement of using multiple threads.

## How can others see the effect of your change?
Use a resource pack like [Hyper Realistic Sky](https://modrinth.com/resourcepack/hyper-realistic-sky) and check the debug menu (F3). The performance hit of such packs should be minor. For this particular pack, you can check performance in three scenarios:
* regular gameplay
* when a tornado is present at time `126650` in a non-desert biome (`/time set 126650`)
* when auroras are present at time `114000` in a snowy biome (`/time set 114000`)

Performance with any animated resource pack has also been improved.

## Links to related issues
#39 

## Which Minecraft versions does this change apply to?
1.20

## Did you test this change on both mod loaders?
- [x] Forge
- [x] Fabric

## Did you unit test this change?
- [x] I unit tested this change.
- [ ] This change is too small to warrant any new unit tests.
- [ ] Other (Please explain below.)

## Areas for improvement (if any)
A new `TextureComponent` handler, `onLayerBelowChange`, would be useful for plugins that add partially-transparent effects and need to alpha blend pixels in their layer based with pixels updated in layers below.

## Additional notes (if any)
Will be backported to older MC versions.